### PR TITLE
feat: basic skeleton for email addresses with styling

### DIFF
--- a/dist/base.css
+++ b/dist/base.css
@@ -1,5 +1,11 @@
 @import url('//fonts.googleapis.com/css2?family=Open+Sans:wght@300;700&display=swap');
 
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
 html,
 body,
 #emails-input {
@@ -14,6 +20,19 @@ body {
   justify-content: center;
   font-family: 'Open Sans', sans-serif;
   font-size: 1rem;
+}
+
+button {
+  background: none;
+  border: 0;
+  outline: none;
+  cursor: pointer;
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 h1 {
@@ -45,7 +64,7 @@ h1 strong {
   border-radius: 0 0 0.5rem 0.5rem;
 }
 
-button {
+button.action-button {
   padding: 0.75rem 1rem;
   font-size: 0.875rem;
   background: #4262ff;
@@ -54,10 +73,6 @@ button {
   border-radius: 0.375rem;
 }
 
-button:first-child {
+button.action-button:first-child {
   margin-right: 0.5rem;
-}
-
-button:hover {
-  cursor: pointer;
 }

--- a/dist/index.html
+++ b/dist/index.html
@@ -14,10 +14,10 @@
           <div id="emails-input"></div>
         </div>
         <div id="actions">
-          <button>
+          <button class="action-button">
             Add Email
           </button>
-          <button>
+          <button class="action-button">
             Get emails count
           </button>
         </div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^components/(.*)$': '<rootDir>/src/components/$1',
+    '^models/(.*)$': '<rootDir>/src/models/$1',
   },
   coveragePathIgnorePatterns: [
     'node_modules',

--- a/package.json
+++ b/package.json
@@ -43,11 +43,15 @@
     "jest": "^26.6.3",
     "jest-dom": "^4.0.0",
     "jest-styled-components": "^7.0.3",
+    "pre-commit": "^1.2.2",
     "prettier": "^2.1.2",
     "typescript": "^4.0.5",
     "webpack": "^5.4.0",
     "webpack-bundle-analyzer": "^4.1.0",
     "webpack-cli": "^4.2.0",
     "webpack-dev-server": "^3.11.0"
-  }
+  },
+  "pre-commit": [
+    "checks"
+  ]
 }

--- a/src/components/emailBlock/emailBlock.css.tsx
+++ b/src/components/emailBlock/emailBlock.css.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { RemoveIcon } from 'components/svg';
+
+export const Container = styled.div`
+  display: flex;
+  padding: 0 0.625rem;
+  height: 1.5rem;
+  background: rgba(102, 153, 255, 0.2);
+  border-radius: 0.75rem;
+  align-items: center;
+`;
+
+export const Text = styled.span`
+  flex: 1;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+`;
+
+export const DeleteButton = styled.button`
+  flex: 0 0 0.75rem;
+`;
+
+export const DeleteIcon = styled(RemoveIcon)`
+  width: 0.5rem;
+  height: 0.5rem;
+`;

--- a/src/components/emailBlock/emailBlock.test.tsx
+++ b/src/components/emailBlock/emailBlock.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { EmailAddress } from 'models';
+import EmailBlock, { Props } from '.';
+
+describe('EmailBlock tests', (): void => {
+  const defaultProps: Props = {
+    emailAddress: {
+      email: 'test@test.nl',
+      id: '123'
+    },
+    onClickDelete: jest.fn(),
+  };
+
+  it('should render the comppnent with the correct details', (): void => {
+    // given
+    const { getByText } = render(<EmailBlock {...defaultProps} />);
+
+    // then
+    expect(getByText('test@test.nl')).toBeTruthy();
+  });
+
+  it('calls to delete an email address on click', (): void => {
+    // given
+    const spyOnClickDelete = jest.fn();
+    const { getByTestId } = render(<EmailBlock {...defaultProps} onClickDelete={spyOnClickDelete} />);
+
+    // then
+    fireEvent.click(getByTestId('delete'));
+
+    expect(spyOnClickDelete).toHaveBeenCalledWith({
+      email: 'test@test.nl',
+      id: '123'
+    });
+  });
+});

--- a/src/components/emailBlock/index.tsx
+++ b/src/components/emailBlock/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { EmailAddress } from 'models';
+import { Container, DeleteIcon, DeleteButton, Text } from './emailBlock.css';
+
+export interface Props {
+  className?: string;
+  emailAddress: EmailAddress;
+  onClickDelete: (emailAddress: EmailAddress) => void;
+};
+
+const EmailBlock = ({className, emailAddress, onClickDelete}: Props): JSX.Element => {
+  const onButtonClick = (): void => onClickDelete(emailAddress);
+
+  return (
+    <Container className={className}>
+      <Text>
+        {emailAddress.email}
+      </Text>
+      <DeleteButton data-testid="delete" onClick={onButtonClick}>
+        <DeleteIcon />
+      </DeleteButton>
+    </Container>
+  );
+};
+
+export default EmailBlock;
+
+
+

--- a/src/components/emailsInput/emailsInput.css.tsx
+++ b/src/components/emailsInput/emailsInput.css.tsx
@@ -1,6 +1,13 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.ul`
   display: block;
-  background: red;
+  background: #fff;
+  border: 1px solid rgb(195, 194, 207);
+  border-radius: 0.25rem;
+`;
+
+export const EmailItem = styled.li`
+  display: inline-block;
+  padding: 0.25rem;
 `;

--- a/src/components/emailsInput/index.tsx
+++ b/src/components/emailsInput/index.tsx
@@ -1,8 +1,44 @@
 import React from 'react';
-import { Container } from './emailsInput.css';
+import { EmailAddress } from 'models';
+import { Container, EmailItem } from './emailsInput.css';
+import EmailBlock from 'components/emailBlock';
 
-const EmailsInput = (): JSX.Element => {
-  return <Container>Hello!!</Container>;
-};
+const data: EmailAddress[] = [
+  {
+    id: '123',
+    email: 'matfin@gmail.com',
+  },
+  {
+    id: '456',
+    email: 'me@mattfinucane.com',
+  },
+  {
+    id: '789',
+    email: 'faeleah@gmail.com',
+  },
+  {
+    id: '1011',
+    email: 'matfin@hotmail.com',
+  },
+  {
+    id: '1213',
+    email: 'e@r.ru',
+  },
+];
+
+const EmailsInput = (): JSX.Element => (
+  <Container>
+    {data.map(
+      (item: EmailAddress): JSX.Element => (
+        <EmailItem key={item.id}>
+          <EmailBlock
+            emailAddress={item}
+            onClickDelete={console.log}
+          />
+        </EmailItem>
+      )
+    )}
+  </Container>
+);
 
 export default EmailsInput;

--- a/src/components/svg.tsx
+++ b/src/components/svg.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface Props {
+  className?: string;
+}
+
+export const RemoveIcon = ({ className }: Props): JSX.Element => (
+  <svg
+    className={className}
+    width="8"
+    height="8"
+    viewBox="0 0 8 8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M8 0.8L7.2 0L4 3.2L0.8 0L0 0.8L3.2 4L0 7.2L0.8 8L4 4.8L7.2 8L8 7.2L4.8 4L8 0.8Z"
+      fill="#050038"
+    />
+  </svg>
+);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './interfaces';

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -1,0 +1,4 @@
+export interface EmailAddress {
+  id: string;
+  email: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,7 @@
     "baseUrl": "./",
     "paths": {
       "components/*": ["src/components/*"],
-      "hooks": ["src/hooks"],
       "models": ["src/models"],
-      "styles": ["src/styles"],
-      "testutils": ["src/testutils"],
-      "utils": ["src/utils"],
-      "views/*": ["src/views/*"],
     },
     "target": "esnext",
     "module": "commonjs",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = (env, { mode }) => ({
   },
   resolve: {
     alias: {
-      'components': path.resolve(__dirname, 'src/components/')
+      'components': path.resolve(__dirname, 'src/components/'),
+      'models': path.resolve(__dirname, 'src/models/')
     },
     extensions: ['.ts', '.tsx', '.js']
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,6 +2488,16 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+concat-stream@^1.4.7:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
@@ -2544,6 +2554,15 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -4921,6 +4940,14 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -5401,6 +5428,11 @@ original@^1.0.0:
   dependencies:
     url-parse "^1.4.3"
 
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
+  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
+
 p-each-series@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
@@ -5610,6 +5642,15 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
+pre-commit@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
+  integrity sha1-287g7p3nI15X95xW186UZBpp7sY=
+  dependencies:
+    cross-spawn "^5.0.1"
+    spawn-sync "^1.0.15"
+    which "1.2.x"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -5681,6 +5722,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.28:
   version "1.8.0"
@@ -5793,7 +5839,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -6427,6 +6473,14 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+spawn-sync@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -6916,6 +6970,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
 typescript@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
@@ -7299,6 +7358,13 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which@1.2.x:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  integrity sha1-mofEN48D6CfOyvGs31bHNsAcFOU=
+  dependencies:
+    isexe "^2.0.0"
+
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -7392,6 +7458,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
#### What is this?
This PR adds the basic set up for the email address component and has the following changes:
- added 'models' with interfaces to ensure type safety for the <EmailBlock /> component
- created the above <EmailBlock /> component with full test coverage
- set up path import aliasing for components and models
- added a pre-commit hook
- added a component to store SVGs