### PR TITLE
feat: batch create multiple comma separated email addresses

### DIFF
--- a/src/components/emailsInput/actionTypes.ts
+++ b/src/components/emailsInput/actionTypes.ts
@@ -1,10 +1,15 @@
-import { EmailAddress } from 'models';
+import { Action, EmailAddress } from 'models';
 
 enum ActionTypes {
+  BATCH_CREATE_EMAIL_ADDRESS = '@emailsInput/BATCH_CREATE_EMAIL_ADDRESS',
   CREATE_EMAIL_ADDRESS = '@emailsInput/CREATE_EMAIL_ADDRESS',
   DELETE_EMAIL_ADDRESS = '@emailsInput/DELETE_EMAIL_ADDRESS',
   RESET_EMAIL_ADDRESS = '@emailsInput/RESET_EMAIL_ADDRESS',
   UPDATE_EMAIL_ADDRESS = '@emailsInput/UPDATE_EMAIL_ADDRESS',
+}
+
+export interface BatchCreateEmailAddresses {
+  type: ActionTypes.BATCH_CREATE_EMAIL_ADDRESS;
 }
 
 export interface CreateEmailAddress {

--- a/src/components/emailsInput/actions.test.ts
+++ b/src/components/emailsInput/actions.test.ts
@@ -10,6 +10,15 @@ describe('actions tests', (): void => {
     spyDispatch.mockClear();
   });
 
+  it('should create a batch of email addresses', (): void => {
+    // given
+    testActions.batchCreateEmailAddresses();
+
+    expect(spyDispatch).toHaveBeenCalledWith({
+      type: ActionTypes.BATCH_CREATE_EMAIL_ADDRESS,
+    });
+  });
+
   it('should create an email address', (): void => {
     // given
     testActions.createEmailAddress();
@@ -25,6 +34,7 @@ describe('actions tests', (): void => {
     const emailAddress: EmailAddress = {
       id: '123',
       email: 'test@test.nl',
+      isValid: true,
     };
 
     // then

--- a/src/components/emailsInput/actions.ts
+++ b/src/components/emailsInput/actions.ts
@@ -2,20 +2,24 @@ import { Action, EmailAddress } from 'models';
 import ActionTypes from './actionTypes';
 
 const actions = (dispatch: React.Dispatch<Action>) => ({
+  batchCreateEmailAddresses: (): void => dispatch({
+    type: ActionTypes.BATCH_CREATE_EMAIL_ADDRESS,
+  }),
+
   createEmailAddress: () => dispatch({
     type: ActionTypes.CREATE_EMAIL_ADDRESS,
   }),
 
-  deleteEmailAddress: (emailAddress: EmailAddress) => dispatch({
+  deleteEmailAddress: (emailAddress: EmailAddress): void => dispatch({
     type: ActionTypes.DELETE_EMAIL_ADDRESS,
     payload: emailAddress,
   }),
 
-  resetEmailAddress: () => dispatch({
+  resetEmailAddress: (): void => dispatch({
     type: ActionTypes.RESET_EMAIL_ADDRESS,
   }),
 
-  updateEmailAdress: (email: string) => dispatch({
+  updateEmailAdress: (email: string): void => dispatch({
     type: ActionTypes.UPDATE_EMAIL_ADDRESS,
     payload: email,
   }),

--- a/src/components/emailsInput/emailsInput.test.tsx
+++ b/src/components/emailsInput/emailsInput.test.tsx
@@ -5,17 +5,20 @@ import { EmailsInput, Props } from './emailsInput';
 
 describe('EmailsInput tests', (): void => {
   const emailAddresses: EmailAddress[] = [
-    { id: '123', email: 'matt@test.one' },
-    { id: '456', email: 'matt@test.two' },
+    { id: '123', email: 'matt@test.one', isValid: true },
+    { id: '456', email: 'matt@test.two', isValid: true },
   ];
 
+  const spyBatchCreateEmailAddresses = jest.fn();
   const spyCreateEmailAddress = jest.fn();
   const spyDeleteEmailAddress = jest.fn();
   const spyResetEmailAddress = jest.fn();
   const spyUpdateEmailAddress = jest.fn();
+
   const defaultProps: Props = {
     email: '',
     emailAddresses: [],
+    batchCreateEmailAddresses: spyBatchCreateEmailAddresses,
     createEmailAddress: spyCreateEmailAddress,
     deleteEmailAddress: spyDeleteEmailAddress,
     resetEmailAddress: spyResetEmailAddress,
@@ -23,6 +26,7 @@ describe('EmailsInput tests', (): void => {
   };
 
   beforeEach((): void => {
+    spyBatchCreateEmailAddresses.mockClear();
     spyCreateEmailAddress.mockClear();
     spyDeleteEmailAddress.mockClear();
     spyResetEmailAddress.mockClear();
@@ -65,6 +69,22 @@ describe('EmailsInput tests', (): void => {
     await waitFor((): void => {
       expect(spyCreateEmailAddress).toHaveBeenCalledTimes(2);
       expect(spyResetEmailAddress).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('calls to save email addresses as a batch when multiple comma separated emails are entered, then resets the email', async (): Promise<void> => {
+    const { getByTestId } = render(
+      <EmailsInput {...defaultProps} />
+    );
+    const input = getByTestId('input');
+    const emails: string = 'one@test.com, two@test.com, three@test.com';
+
+    // then
+    fireEvent.change(input, { target: { value: emails } });
+
+    await waitFor((): void => {
+      expect(spyBatchCreateEmailAddresses).toHaveBeenCalled();
+      expect(spyResetEmailAddress).toHaveBeenCalled();
     });
   });
 

--- a/src/components/emailsInput/emailsInput.tsx
+++ b/src/components/emailsInput/emailsInput.tsx
@@ -7,6 +7,7 @@ import EmailBlock from 'components/emailBlock';
 export interface Props {
   email: string;
   emailAddresses: EmailAddress[],
+  batchCreateEmailAddresses: () => void;
   createEmailAddress: () => void;
   deleteEmailAddress: (emailAddress: EmailAddress) => void;
   resetEmailAddress: () => void;
@@ -16,6 +17,7 @@ export interface Props {
 export const EmailsInput = ({
   email,
   emailAddresses,
+  batchCreateEmailAddresses,
   createEmailAddress,
   deleteEmailAddress,
   resetEmailAddress,
@@ -23,7 +25,16 @@ export const EmailsInput = ({
 }: Props): JSX.Element => {
   const onInputChange = ({
     target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => updateEmailAddress(value);
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    const splitValues: string[] = value.split(',');
+
+    updateEmailAddress(value);
+
+    if(splitValues.length > 1) {
+      batchCreateEmailAddresses();
+      resetEmailAddress();
+    }
+  };
 
   const saveEmailAddress = () => {
     if (email.length > 0) {

--- a/src/components/emailsInput/index.tsx
+++ b/src/components/emailsInput/index.tsx
@@ -12,6 +12,7 @@ const ContainerComponent = (): JSX.Element => {
     <EmailsInput
       email={email}
       emailAddresses={emailAddresses}
+      batchCreateEmailAddresses={actions.batchCreateEmailAddresses}
       createEmailAddress={actions.createEmailAddress}
       deleteEmailAddress={actions.deleteEmailAddress}
       resetEmailAddress={actions.resetEmailAddress}

--- a/src/components/emailsInput/reducer.test.ts
+++ b/src/components/emailsInput/reducer.test.ts
@@ -9,6 +9,27 @@ describe('reducer', (): void => {
     email: 'test@test.nl',
   };
 
+  it('updates the state when creating a batch of email addresses', (): void => {
+    const state: EmailsInputState = reducer(
+      {
+        ...defaultState,
+        email: 'matfin@gmail.com, somewhere,,, invalid, another@email.yu,',
+      },
+      {
+        type: ActionTypes.BATCH_CREATE_EMAIL_ADDRESS,
+      }
+    );
+
+    const check: EmailsInputState = {
+      email: 'matfin@gmail.com, somewhere,,, invalid, another@email.yu,',
+      emailAddresses: [
+        { id: expect.any(String), email: 'matfin@gmail.com', isValid: true },
+        { id: expect.any(String), email: 'somewhere', isValid: false },
+        { id: expect.any(String), email: 'another@email.yu', isValid: true },
+      ]
+    }
+  });
+
   it('updates the state when creating an email address', (): void => {
     const state: EmailsInputState = reducer(
       {

--- a/src/components/emailsInput/reducer.ts
+++ b/src/components/emailsInput/reducer.ts
@@ -8,15 +8,32 @@ export const defaultState: EmailsInputState = {
   email: '',
 };
 
-const reducer = (
-  state = defaultState,
-  action: Action,
-): EmailsInputState => {
+const reducer = (state = defaultState, action: Action): EmailsInputState => {
   const { payload, type } = action;
 
-  switch(type) {
+  switch (type) {
+    case ActionTypes.BATCH_CREATE_EMAIL_ADDRESS: {
+      const { email, emailAddresses } = state;
+      const splitValues: string[] = email
+        .split(',')
+        .map((item: string): string => item.trim())
+        .filter((item: string) => item.length > 0);
+      const newEmailAddresses: EmailAddress[] = splitValues.map(
+        (email: string): EmailAddress => ({
+          id: uuid(),
+          email,
+          isValid: isValidEmail(email),
+        })
+      );
+
+      return {
+        ...state,
+        emailAddresses: [...emailAddresses, ...newEmailAddresses],
+      }
+    }
+
     case ActionTypes.CREATE_EMAIL_ADDRESS: {
-      const { email } = state;
+      const { email, emailAddresses } = state;
       const id = uuid();
       const newEmailAddress: EmailAddress = {
         email,
@@ -26,14 +43,16 @@ const reducer = (
 
       return {
         ...state,
-        emailAddresses: [...state.emailAddresses, newEmailAddress]
+        emailAddresses: [...emailAddresses, newEmailAddress],
       };
     }
 
     case ActionTypes.DELETE_EMAIL_ADDRESS: {
       const { emailAddresses } = state;
       const emailAddress = payload as EmailAddress;
-      const updatedEmailAddresses: EmailAddress[] = emailAddresses.filter((item: EmailAddress) => item.id !== emailAddress.id);
+      const updatedEmailAddresses: EmailAddress[] = emailAddresses.filter(
+        (item: EmailAddress) => item.id !== emailAddress.id
+      );
 
       return {
         ...state,
@@ -50,6 +69,7 @@ const reducer = (
 
     case ActionTypes.UPDATE_EMAIL_ADDRESS: {
       const email = payload as string;
+
       return {
         ...state,
         email,


### PR DESCRIPTION
#### What is this?
This PR adds the ability to add batches of email addresses when the user pastes in a comma separated list.

If a batch of email addresses are added with some missing, this edge case is taken care of, so something like `test@one.ie,,,another@user.de, test@again.com,,,,` will filter out empty entries and add only those that are valid strings.