### PR TITLE
feat: create hook to add a random email address

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,10 +14,10 @@
           <div id="emails-input"></div>
         </div>
         <div id="actions">
-          <button class="action-button">
+          <button id="add-email" class="action-button">
             Add Email
           </button>
-          <button class="action-button">
+          <button id="get-count" class="action-button">
             Get emails count
           </button>
         </div>
@@ -25,9 +25,36 @@
     </div>
     <script src="emails-input.js"></script>
     <script type="text/javascript">
-      var node = document.querySelector('#emails-input');
+      var root = document.querySelector('#emails-input');
+      var emailAddresses = [
+        'me@mattfinucane.com',
+        'test@one.nl',
+        'another@two.de',
+        'three@four.ru',
+        'five@six-seven.yu',
+        'someone@somewhere.com',
+      ];
+      var randomNumberInRange = function (min, max) {
+        return Math.floor(Math.random() * (max - min) + min);
+      };
 
-      TestEmailsInput(node);
+      // initialise the component
+      emailBoard.init(root);
+
+      // add a random email
+      document.querySelector('#add-email').addEventListener('click', function () {
+        var index = randomNumberInRange(0, emailAddresses.length);
+
+        emailBoard.addRandomEmail(emailAddresses[index]);
+      });
+
+      // get email count
+      document.querySelector('#get-count').addEventListener('click', function () {
+        var emailBlockNodes = document.querySelectorAll('#emails-input div[data-testid="email-block"]');
+
+        alert(emailBlockNodes.length);
+      });
+
     </script>
   </body>
 </html>

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,6 @@
 export {};
 declare global {
   interface Window {
-    [index: string]: any
+    [index: string]: any;
   }
 }

--- a/src/components/emailsInput/index.tsx
+++ b/src/components/emailsInput/index.tsx
@@ -1,12 +1,19 @@
 import React, { useReducer } from 'react';
 import emailsInputActions from './actions';
 import emailsInputReducer, { defaultState } from './reducer';
+import { useEmailAdded } from 'hooks';
 import { EmailsInput } from './emailsInput';
 
 const ContainerComponent = (): JSX.Element => {
   const [state, dispatch] = useReducer(emailsInputReducer, defaultState);
   const actions = emailsInputActions(dispatch);
   const { emailAddresses, email } = state;
+
+  useEmailAdded(({ detail }: any): void => {
+    actions.updateEmailAdress(detail);
+    actions.createEmailAddress();
+    actions.resetEmailAddress();
+  });
 
   return (
     <EmailsInput

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useEmailAdded';
 export * from './useKeyDown';

--- a/src/hooks/useEmailAdded.test.ts
+++ b/src/hooks/useEmailAdded.test.ts
@@ -1,0 +1,16 @@
+import { fireEvent, render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useEmailAdded } from './useEmailAdded';
+
+describe('useEmailAdded hook', (): void => {
+  it('should run the callback when the custom event is fired', (): void => {
+    // given
+    const spyCb = jest.fn();
+    const event = { detail: 'test@test.nl' };
+
+    // then
+    renderHook((): void => useEmailAdded(spyCb));
+    fireEvent(window, new CustomEvent('emails:add', event));
+    expect(spyCb).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useEmailAdded.ts
+++ b/src/hooks/useEmailAdded.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+export const useEmailAdded = (cb: (e: any) => void): void => {
+  useEffect((): (() => void) => {
+    window.addEventListener('emails:add', cb);
+
+    return (): void => window.removeEventListener('emails:add', cb);
+  });
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { publishEvent } from 'utils';
 import EmailsInput from 'components/emailsInput';
 
-const TestEmailsInput = (attachTo: HTMLElement): void => {
+const init = (attachTo: HTMLElement): void => {
   ReactDOM.render(<EmailsInput />, attachTo);
 };
 
-window.TestEmailsInput = TestEmailsInput;
+const addRandomEmail = (email: string): void => {
+  publishEvent('emails:add', { detail: email });
+};
+
+window.emailBoard = {
+  init,
+  addRandomEmail,
+}

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -3,3 +3,7 @@ export interface EmailAddress {
   id: string;
   isValid: boolean;
 }
+
+export interface CustomEventProps {
+  detail: any
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,13 @@
+import { CustomEventProps } from 'models';
+
 export const isValidEmail = (email?: string): boolean => {
   const re: RegExp = RegExp(/(.+)@(.+){2,}\.(.+){2,}/);
 
   return re.test(email ?? '');
+};
+
+export const publishEvent = (name: string, payload: CustomEventProps): void => {
+  const event: CustomEvent = new CustomEvent(name, payload);
+
+  window.dispatchEvent(event);
 };

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { isValidEmail } from '.';
+import { isValidEmail, publishEvent } from '.';
 
 describe('utils tests', (): void => {
   it('should validate an email address', (): void => {
@@ -6,5 +6,18 @@ describe('utils tests', (): void => {
     expect(isValidEmail()).toBe(false);
     expect(isValidEmail('matfin@hotmail.com')).toBe(true);
     expect(isValidEmail('matt.finucane@miro.com')).toBe(true);
+  });
+
+  it('should call to dispatch a custom event', (): void => {
+    // given
+    const eventName = 'test:custom';
+
+    window.dispatchEvent = jest.fn();
+
+    // then
+    publishEvent(eventName, { detail: 'test' });
+    expect(window.dispatchEvent).toHaveBeenCalledWith(
+      new CustomEvent(eventName, { detail: 'test' })
+    );
   });
 });


### PR DESCRIPTION
#### What is this?
This PR adds two new features as follows:
- clicking on the 'Add email' button randomly selects an email from a list and creates it in the app
- clicking on the 'Get emails count' button counts the number of emails already created

#### How?
The cleanest solution to bridge between the app and the Javascript in index.html was to make the use of custom event dispatches and hooks to add a new email address.