### PR TITLE
feat: make container width flexible and add scroll to editor area

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,13 +11,4 @@
     "@babel/typescript",
     "@babel/react"
   ]
-  // "plugins": [
-  //   "babel-plugin-styled-components",
-  //   "@babel/plugin-proposal-object-rest-spread",
-  //   "@babel/plugin-proposal-class-properties",
-  //   "@babel/plugin-proposal-export-namespace-from",
-  //   "@babel/plugin-syntax-dynamic-import",
-  //   "@babel/plugin-proposal-export-default-from",
-  //   "@babel/plugin-proposal-optional-chaining"
-  // ]
 }

--- a/dist/base.css
+++ b/dist/base.css
@@ -47,12 +47,15 @@ h1 strong {
 }
 
 #container {
-  width: 35rem;
+  width: 70%;
+  min-width: 25rem;
+  max-width: 35rem;
   box-shadow: 0px 8px 20px rgba(0, 0, 0, 0.2);
   border-radius: 0.5rem;
 }
 
 #editor {
+  width: 100%;
   padding: 2rem 3.125rem 1.5rem 3.125rem;
   background: #f8f8f7;
   border-radius: 0.5rem 0.5rem 0 0;
@@ -60,6 +63,7 @@ h1 strong {
 }
 
 #actions {
+  width: 100%;
   padding: 1.5rem 3.125rem;
   background: #fff;
   border-radius: 0 0 0.5rem 0.5rem;

--- a/dist/index.html
+++ b/dist/index.html
@@ -8,19 +8,17 @@
   </head>
   <body>
     <div id="container">
-      <div id="container">
-        <div id="editor">
-          <h1>Share <strong>Board name</strong> with others</h1>
-          <div id="emails-input"></div>
-        </div>
-        <div id="actions">
-          <button id="add-email" class="action-button">
-            Add Email
-          </button>
-          <button id="get-count" class="action-button">
-            Get emails count
-          </button>
-        </div>
+      <div id="editor">
+        <h1>Share <strong>Board name</strong> with others</h1>
+        <div id="emails-input"></div>
+      </div>
+      <div id="actions">
+        <button id="add-email" class="action-button">
+          Add Email
+        </button>
+        <button id="get-count" class="action-button">
+          Get emails count
+        </button>
       </div>
     </div>
     <script src="emails-input.js"></script>

--- a/src/components/emailsInput/emailsInput.css.tsx
+++ b/src/components/emailsInput/emailsInput.css.tsx
@@ -3,9 +3,11 @@ import InputBocComponent from 'components/inputbox';
 
 export const Container = styled.ul`
   display: block;
+  max-height: 6rem;
   background: #fff;
   border: 1px solid rgb(195, 194, 207);
   border-radius: 0.25rem;
+  overflow-y: scroll;
 `;
 
 export const BoxItem = styled.li`


### PR DESCRIPTION
#### What is this?
This PR adds some UI tweaks and fixes to fulfil requirements as follows:
- the width of the container for adding emails is flexible, and email blocks will flow according to the container width.
- when many emails are added to the container, it will scroll.